### PR TITLE
Hid API Keys using environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 *.zip
 cockroach*
+config.js

--- a/index.html
+++ b/index.html
@@ -5,10 +5,10 @@
   <title>Going Places</title>
   <link rel="icon" href="/public/images/favicon.ico">
   <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
-  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC5Eu1mlMfUFkBI7tsMwvDL1TBhwmxFBGQ&callback=main&libraries=places&v=weekly" defer></script>
+  <script id = "google" src="https://maps.googleapis.com/maps/api/js?key=" defer></script>
+  <script type='text/javascript' src='config.js'></script>
+  <script type='text/javascript' src='setKey.js'></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-  <!-- <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCqFNIkXGnIREGxDKlgrhYjpNHpWS9y6PQ&libraries=places"></script> -->
-  
   
   <!-- Stylesheets. -->
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"

--- a/setKey.js
+++ b/setKey.js
@@ -1,0 +1,2 @@
+document.getElementById("google").src = "https://maps.googleapis.com/maps/api/js?key=" + config.GOOGLE_KEY + "&callback=main&libraries=places&v=weekly";
+console.log(document.getElementById("google").src);


### PR DESCRIPTION
Hide API keys; requires file `config.json` to be populated as such:
```js
var config = {
        GOOGLE_KEY = "API_KEY"
}
```